### PR TITLE
Use public HTTPS repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:xrkffgg/k-progress.git"
+    "url": "git+https://github.com/xrkffgg/k-progress.git"
   },
   "author": "xrkffgg",
   "homepage": "https://xrkffgg.github.io/Knotes/course/k-progress.html",


### PR DESCRIPTION
## Summary

Update the package metadata to use the public HTTPS GitHub repository URL instead of the SSH-style URL.

## Why

This package is publicly available on npm, so its repository metadata should not require SSH/GitHub key access for users or automated tooling to resolve the source repository.

## Validation

- Metadata assertion: `repository.url` is now `git+https://github.com/xrkffgg/k-progress.git`
- `git diff --check`
- `git ls-remote https://github.com/xrkffgg/k-progress.git HEAD`
- `pnpm install --ignore-scripts --lockfile=false`
- `pnpm --package=npm@11.13.0 dlx npm pack --dry-run`

Notes:

- `pnpm run package` currently fails before this metadata change because the legacy build stack uses `node-sass@4`, which does not support this macOS arm64 / current Node runtime, and the old pug loader also reports a query-string parse error.
- I did not commit dependency or lockfile changes.
